### PR TITLE
MNT: Remove uproot-base build ouptut

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,5 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-target_platform:
-- linux-64

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: ROOT I/O in pure Python and NumPy.
 
 Development: https://github.com/scikit-hep/uproot5
 
-Documentation: https://uproot.readthedocs.io/en/latest/
+Documentation: https://uproot.readthedocs.io/en/stable/
 
 uproot (originally μproot, for "micro-Python ROOT") is a reader and a writer
 of the ROOT file format using only Python and Numpy. Unlike the standard C++
@@ -40,7 +40,6 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-uproot-green.svg)](https://anaconda.org/conda-forge/uproot) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/uproot.svg)](https://anaconda.org/conda-forge/uproot) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/uproot.svg)](https://anaconda.org/conda-forge/uproot) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/uproot.svg)](https://anaconda.org/conda-forge/uproot) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-uproot--base-green.svg)](https://anaconda.org/conda-forge/uproot-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/uproot-base.svg)](https://anaconda.org/conda-forge/uproot-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/uproot-base.svg)](https://anaconda.org/conda-forge/uproot-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/uproot-base.svg)](https://anaconda.org/conda-forge/uproot-base) |
 
 Installing uproot
 =================
@@ -52,16 +51,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `uproot, uproot-base` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `uproot` can be installed with `conda`:
 
 ```
-conda install uproot uproot-base
+conda install uproot
 ```
 
 or with `mamba`:
 
 ```
-mamba install uproot uproot-base
+mamba install uproot
 ```
 
 It is possible to list all of the versions of `uproot` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,54 +6,38 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/uproot-{{ version }}.tar.gz
   sha256: b8332c76baf3f327f84972a9b4d55a72c153f324331cdb85a1b0490bd14cf1b1
 
 build:
-  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 1
 
-outputs:
-  - name: uproot-base
-    build:
-      noarch: python
-      script:
-        - python -m pip install . --no-deps -vv
-    requirements:
-      host:
-        - python >=3.8
-        - hatchling >1.10.0
-        - hatch-vcs
-        - pip
-      run:
-        - python >=3.8
-        - numpy
-        - packaging
-        - awkward >=2.4.6
-        - fsspec
-        - cramjam >=2.5.0
-        - python-xxhash
-        - typing_extensions >=4.1.0
-    test:
-      imports:
-        - uproot
-        - uproot.behaviors
-      commands:
-        - pip check
-      requires:
-        - pip
+requirements:
+  host:
+    - python >=3.8
+    - hatchling >1.10.0
+    - hatch-vcs
+    - pip
+  run:
+    - python >=3.8
+    - awkward >=2.4.6
+    - cramjam >=2.5.0
+    - python-xxhash
+    - numpy
+    - fsspec
+    - packaging
+    - typing_extensions >=4.1.0  # python < 3.11
 
-  - name: uproot
-    build:
-      noarch: python
-
-    requirements:
-      run:
-        - {{ pin_subpackage('uproot-base', exact=True) }}
-        # Other common requirements
-    test:
-      imports:
-        - uproot
-        - uproot.behaviors
+test:
+  imports:
+    - uproot
+    - uproot.behaviors
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/scikit-hep/uproot5
@@ -68,7 +52,7 @@ about:
     root_numpy, uproot does not depend on C++ ROOT. Instead, it uses Numpy calls
     to rapidly cast data blocks in the ROOT file as Numpy arrays.
   dev_url: https://github.com/scikit-hep/uproot5
-  doc_url: https://uproot.readthedocs.io/en/latest/
+  doc_url: https://uproot.readthedocs.io/en/stable/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
* As of `v5.4.0` the requirements of the `uproot-base` and `uproot` build outputs are identical. This removes the need for `uproot-base` and the feedstock can now produce just the `uproot` build output.
   - c.f. PR https://github.com/conda-forge/uproot-feedstock/pull/157
* Rerender the `meta.yaml` using `grayskull pypi uproot`.
* Use the stable docs URL.
* Bump the build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
